### PR TITLE
Added experimental features flag for linux

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,61 +1,66 @@
-const electron = require('electron')
+const electron = require("electron");
 // Module to control application life.
-const app = electron.app
+const app = electron.app;
 // Module to create native browser window.
-const BrowserWindow = electron.BrowserWindow
+const BrowserWindow = electron.BrowserWindow;
 
-app
-  .commandLine
-  .appendSwitch('enable-web-bluetooth', true);
+if (process.platform === "linux"){
+  app.commandLine.appendSwitch("enable-experimental-web-platform-features", true);
+} 
+app.commandLine.appendSwitch("enable-web-bluetooth", true);
 
-const path = require('path')
-const url = require('url')
+
+const path = require("path");
+const url = require("url");
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
-let mainWindow
+let mainWindow;
 
 function createWindow() {
   // Create the browser window.
-  mainWindow = new BrowserWindow({width: 800, height: 600})
+  mainWindow = new BrowserWindow({ width: 800, height: 600 });
   //mainWindow.loadURL('http://google.com') and load the index.html of the app.
-  mainWindow.loadURL(url.format({
-    pathname: path.join(__dirname, 'index.html'),
-    protocol: 'file:',
-    slashes: true
-  }))
+  mainWindow.loadURL(
+    url.format({
+      pathname: path.join(__dirname, "index.html"),
+      protocol: "file:",
+      slashes: true
+    })
+  );
 
   // Open the DevTools. mainWindow.webContents.openDevTools() Emitted when the
   // window is closed.
-  mainWindow.on('closed', function () {
+  mainWindow.on("closed", function() {
     // Dereference the window object, usually you would store windows in an array if
     // your app supports multi windows, this is the time when you should delete the
     // corresponding element.
-    mainWindow = null
-  })
+    mainWindow = null;
+  });
 }
 
 // This method will be called when Electron has finished initialization and is
 // ready to create browser windows. Some APIs can only be used after this event
 // occurs.
-app.on('ready', createWindow)
+app.on("ready", createWindow);
 
 // Quit when all windows are closed.
-app.on('window-all-closed', function () {
+app.on("window-all-closed", function() {
   // On OS X it is common for applications and their menu bar to stay active until
   // the user quits explicitly with Cmd + Q
-  if (process.platform !== 'darwin') {
-    app.quit()
+  if (process.platform !== "darwin") {
+    app.quit();
   }
-})
+});
 
-app.on('activate', function () {
+app.on("activate", function() {
   // On OS X it's common to re-create a window in the app when the dock icon is
   // clicked and there are no other windows open.
   if (mainWindow === null) {
-    createWindow()
+    createWindow();
   }
-})
+});
 
 // In this file you can include the rest of your app's specific main process
 // code. You can also put them in separate files and require them here.
+

--- a/main.js
+++ b/main.js
@@ -1,66 +1,65 @@
-const electron = require("electron");
+const electron = require('electron')
 // Module to control application life.
-const app = electron.app;
+const app = electron.app
 // Module to create native browser window.
-const BrowserWindow = electron.BrowserWindow;
+const BrowserWindow = electron.BrowserWindow
 
 if (process.platform === "linux"){
   app.commandLine.appendSwitch("enable-experimental-web-platform-features", true);
-} 
-app.commandLine.appendSwitch("enable-web-bluetooth", true);
+}
 
+app
+  .commandLine
+  .appendSwitch('enable-web-bluetooth', true);
 
-const path = require("path");
-const url = require("url");
+const path = require('path')
+const url = require('url')
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
-let mainWindow;
+let mainWindow
 
 function createWindow() {
   // Create the browser window.
-  mainWindow = new BrowserWindow({ width: 800, height: 600 });
+  mainWindow = new BrowserWindow({width: 800, height: 600})
   //mainWindow.loadURL('http://google.com') and load the index.html of the app.
-  mainWindow.loadURL(
-    url.format({
-      pathname: path.join(__dirname, "index.html"),
-      protocol: "file:",
-      slashes: true
-    })
-  );
+  mainWindow.loadURL(url.format({
+    pathname: path.join(__dirname, 'index.html'),
+    protocol: 'file:',
+    slashes: true
+  }))
 
   // Open the DevTools. mainWindow.webContents.openDevTools() Emitted when the
   // window is closed.
-  mainWindow.on("closed", function() {
+  mainWindow.on('closed', function () {
     // Dereference the window object, usually you would store windows in an array if
     // your app supports multi windows, this is the time when you should delete the
     // corresponding element.
-    mainWindow = null;
-  });
+    mainWindow = null
+  })
 }
 
 // This method will be called when Electron has finished initialization and is
 // ready to create browser windows. Some APIs can only be used after this event
 // occurs.
-app.on("ready", createWindow);
+app.on('ready', createWindow)
 
 // Quit when all windows are closed.
-app.on("window-all-closed", function() {
+app.on('window-all-closed', function () {
   // On OS X it is common for applications and their menu bar to stay active until
   // the user quits explicitly with Cmd + Q
-  if (process.platform !== "darwin") {
-    app.quit();
+  if (process.platform !== 'darwin') {
+    app.quit()
   }
-});
+})
 
-app.on("activate", function() {
+app.on('activate', function () {
   // On OS X it's common to re-create a window in the app when the dock icon is
   // clicked and there are no other windows open.
   if (mainWindow === null) {
-    createWindow();
+    createWindow()
   }
-});
+})
 
 // In this file you can include the rest of your app's specific main process
 // code. You can also put them in separate files and require them here.
-


### PR DESCRIPTION
The repo as it stands doesn't support Linux. For some reason, web bluetooth doesn't seem to be enabled with the `enable-web-bluetooth` flag.

However, we found that it works beautifully if you also add the `enable-experimental-web-platform-features` flag. So, I've added it to the repo to help anyone else trying to build BLE Electron apps on Linux